### PR TITLE
Update crowdhandler.php

### DIFF
--- a/crowdhandler.php
+++ b/crowdhandler.php
@@ -18,7 +18,6 @@
  * Description:       During periods of heavy traffic, our queue management solution helps safeguard your website from crashing and protects your sales.
  * Version:           1.0.0
  * Author:            CROWDHANDLER LTD
- * Author URI:        https://signup.crowdhandler.com/?utm_source=WordPress&utm_medium=Plugin_Dir
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       crowdhandler


### PR DESCRIPTION
Removed author URI to clear validation error:

> Error: Your plugin and author URIs are the same. Your plugin headers in the main plugin file headers have the same value for both the plugin and author URI (Uniform Resource Identifier). A plugin URI is a webpage that provides details about this specific plugin. An author URI is a webpage that provides information about the author of the plugin. Those two must be different. You are not required to provide both, so pick the one that best applies to your situation.